### PR TITLE
Drawing circle directly on texture

### DIFF
--- a/editor/include/save_button.h
+++ b/editor/include/save_button.h
@@ -3,6 +3,8 @@
 #ifndef EDITOR_INCLUDE_SAVE_BUTTON_H_
 #define EDITOR_INCLUDE_SAVE_BUTTON_H_
 
+#include <string>
+
 #include "include/button.h"
 #include "include/icosphere.h"
 #include "include/console_view.h"


### PR DESCRIPTION
- Drawing circle on texture without support masks
- Removed origin triangle masking. Not critical because we have bounding rectangle of triangle.
