### PR TITLE
Icosphere vbo performance v2

### DIFF
--- a/model/include/icosphere.h
+++ b/model/include/icosphere.h
@@ -59,12 +59,8 @@ class Icosphere {
   std::vector<Triangle*> init_triangles_;
   // All triangles.
   std::vector<Triangle*> all_triangles_;
-  float* vertices_array_;
   uint16_t* indices_array_;
   uint16_t* tex_coord_array_;
-  // Using for drawing icosphere grid. One color for internal vertices, other
-  // color for vertices on initial edges.
-  uint8_t* colors_array_;
   uint8_t n_splits_;
   unsigned coordinates_vbo_;
   unsigned norms_vbo_;

--- a/model/include/icosphere.h
+++ b/model/include/icosphere.h
@@ -67,6 +67,7 @@ class Icosphere {
   uint8_t* colors_array_;
   uint8_t n_splits_;
   unsigned coordinates_vbo_;
+  unsigned norms_vbo_;
   unsigned normals_vbo_;
   unsigned tex_coords_vbo_;
   bool need_to_update_vbo_;

--- a/model/include/structures.h
+++ b/model/include/structures.h
@@ -26,6 +26,8 @@ class Point3f {
 
   void GetPosition(float* dst) const;
 
+  void GetPosition(int16_t* dst, float* norm) const;
+
   void SetColor(uint8_t r, uint8_t g, uint8_t b);
 
   void SetColor(const uint8_t* src);

--- a/model/include/structures.h
+++ b/model/include/structures.h
@@ -10,8 +10,7 @@
 class Edge;
 class Point3f {
  public:
-  Point3f(uint16_t id, float x, float y, float z, float* vertices_array_offset,
-          uint8_t* colors_array_offset);
+  explicit Point3f(uint16_t id, float x = 0, float y = 0, float z = 0);
 
   static void MiddlePoint(const Point3f& p1, const Point3f& p2,
                           Point3f* middle_point);
@@ -28,9 +27,9 @@ class Point3f {
 
   void GetPosition(int16_t* dst, float* norm) const;
 
-  void SetColor(uint8_t r, uint8_t g, uint8_t b);
-
   void SetColor(const uint8_t* src);
+
+  void GetColor(uint8_t* dst) const;
 
   float GetNorm() const { return norm_; }
 
@@ -48,11 +47,11 @@ class Point3f {
 
  private:
   uint16_t id_;
-  float* vertices_array_offset_;
-  uint8_t* colors_array_offset_;
   float norm_;
   std::vector<Point3f*> neighborhood_;
   std::vector<Edge*> edges_;
+  std::vector<uint8_t> color_;
+  std::vector<float> coordinates_;
 };
 
 class Edge {

--- a/model/src/structures.cpp
+++ b/model/src/structures.cpp
@@ -10,10 +10,8 @@
 #include <vector>
 
 // Point3f ---------------------------------------------------------------------
-Point3f::Point3f(uint16_t id, float x, float y, float z,
-                 float* vertices_array_offset, uint8_t* colors_array_offset)
-  : id_(id), vertices_array_offset_(vertices_array_offset),
-    colors_array_offset_(colors_array_offset) {
+Point3f::Point3f(uint16_t id, float x, float y, float z)
+  : id_(id), color_(3, 0), coordinates_(3) {
   SetPosition(x, y, z);
   neighborhood_.reserve(6);  // Maximal numer of neighbors.
   edges_.reserve(6);
@@ -21,41 +19,43 @@ Point3f::Point3f(uint16_t id, float x, float y, float z,
 
 void Point3f::Normalize(float target_norm) {
   float coeff = target_norm / norm_;
-  vertices_array_offset_[0] *= coeff;
-  vertices_array_offset_[1] *= coeff;
-  vertices_array_offset_[2] *= coeff;
+  coordinates_[0] *= coeff;
+  coordinates_[1] *= coeff;
+  coordinates_[2] *= coeff;
   norm_ = target_norm;
 }
 
 void Point3f::SetPosition(float x, float y, float z) {
-  vertices_array_offset_[0] = x;
-  vertices_array_offset_[1] = y;
-  vertices_array_offset_[2] = z;
+  coordinates_[0] = x;
+  coordinates_[1] = y;
+  coordinates_[2] = z;
   norm_ = sqrt(x * x + y * y + z * z);
 }
 
-void Point3f::SetColor(uint8_t r, uint8_t g, uint8_t b) {
-  colors_array_offset_[0] = r;
-  colors_array_offset_[1] = g;
-  colors_array_offset_[2] = b;
+void Point3f::SetColor(const uint8_t* src) {
+  color_[0] = src[0];
+  color_[1] = src[1];
+  color_[2] = src[2];
 }
 
-void Point3f::SetColor(const uint8_t* src) {
-  memcpy(colors_array_offset_, src, sizeof(uint8_t) * 3);
+void Point3f::GetColor(uint8_t* dst) const {
+  dst[0] = color_[0];
+  dst[1] = color_[1];
+  dst[2] = color_[2];
 }
 
 void Point3f::MiddlePoint(const Point3f& p1, const Point3f& p2,
                           Point3f* middle_point) {
   middle_point->SetPosition(
-    0.5f * (p1.vertices_array_offset_[0] + p2.vertices_array_offset_[0]),
-    0.5f * (p1.vertices_array_offset_[1] + p2.vertices_array_offset_[1]),
-    0.5f * (p1.vertices_array_offset_[2] + p2.vertices_array_offset_[2]));
+    0.5f * (p1.coordinates_[0] + p2.coordinates_[0]),
+    0.5f * (p1.coordinates_[1] + p2.coordinates_[1]),
+    0.5f * (p1.coordinates_[2] + p2.coordinates_[2]));
 }
 
 float Point3f::SquaredDistanceTo(float x, float y, float z) {
-  return pow(vertices_array_offset_[0] - x, 2) +
-         pow(vertices_array_offset_[1] - y, 2) +
-         pow(vertices_array_offset_[2] - z, 2);
+  return pow(coordinates_[0] - x, 2) +
+         pow(coordinates_[1] - y, 2) +
+         pow(coordinates_[2] - z, 2);
 }
 
 void Point3f::AddNeighbor(Point3f* point, Edge* edge) {
@@ -69,18 +69,20 @@ void Point3f::GetNeighborhood(std::vector<Point3f*>* neighborhood) {
 }
 
 void Point3f::GetPosition(float* x, float* y, float* z) const {
-  *x = vertices_array_offset_[0];
-  *y = vertices_array_offset_[1];
-  *z = vertices_array_offset_[2];
+  *x = coordinates_[0];
+  *y = coordinates_[1];
+  *z = coordinates_[2];
 }
 
 void Point3f::GetPosition(float* dst) const {
-  memcpy(dst, vertices_array_offset_, sizeof(float) * 3);
+  dst[0] = coordinates_[0];
+  dst[1] = coordinates_[1];
+  dst[2] = coordinates_[2];
 }
 
 void Point3f::GetPosition(int16_t* dst, float* norm) const {
   for (uint8_t i = 0; i < 3; ++i) {
-    dst[i] = INT16_MAX * (vertices_array_offset_[i] / norm_);
+    dst[i] = INT16_MAX * (coordinates_[i] / norm_);
   }
   *norm = norm_;
 }

--- a/model/src/structures.cpp
+++ b/model/src/structures.cpp
@@ -78,6 +78,13 @@ void Point3f::GetPosition(float* dst) const {
   memcpy(dst, vertices_array_offset_, sizeof(float) * 3);
 }
 
+void Point3f::GetPosition(int16_t* dst, float* norm) const {
+  for (uint8_t i = 0; i < 3; ++i) {
+    dst[i] = INT16_MAX * (vertices_array_offset_[i] / norm_);
+  }
+  *norm = norm_;
+}
+
 void Point3f::ResetNeighborhood() {
   neighborhood_.clear();
   edges_.clear();

--- a/res/shaders/planet_shader.vertex
+++ b/res/shaders/planet_shader.vertex
@@ -1,6 +1,7 @@
 attribute vec3 a_position;
 attribute vec3 a_normal;
 attribute vec2 a_tex_coord;
+attribute float a_norm;
 
 uniform mat4 u_modelview_matrix;
 uniform mat4 u_projection_matrix;
@@ -12,7 +13,7 @@ varying vec3 v_position;
 void main() {
   v_normal = a_normal;
   v_tex_coord = a_tex_coord;
-  gl_Position = u_modelview_matrix * vec4(a_position, 1.0);
+  gl_Position = u_modelview_matrix * vec4(a_position * a_norm, 1.0);
   v_position = vec3(gl_Position[0], gl_Position[1], gl_Position[2]);
   gl_Position = u_projection_matrix * gl_Position;
 }


### PR DESCRIPTION
- Removed indents to colors and coordinates data from Point3f.
- x3 floating coordinates per vertex replaced to x3 signed shorts and x1 float as norm. This gives 10 bytes versus 12 bytes per each vertex then transferring to GPU. 
